### PR TITLE
Support for AppleCore ModifyFoodValue Function

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,17 @@ jar {
 		classifier = 'complete'
 }
 
+repositories {
+	maven {
+		url "http://www.ryanliptak.com/maven/"
+	}
+}
+
 dependencies {
 	compile 'org.ow2.asm:asm-debug-all:5.0.3'
+	
+	compile "applecore:AppleCore:1.7.10-1.3.1+171.f62ad:api"
+	
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..
     //compile "some.group:artifact:version:classifier"

--- a/src/main/java/com/jeffpeng/jmod/JMOD.java
+++ b/src/main/java/com/jeffpeng/jmod/JMOD.java
@@ -12,7 +12,7 @@ import com.jeffpeng.jmod.asm.JMODObfuscationHelper;
 import com.jeffpeng.jmod.crafting.ToolUnbreaker;
 import com.jeffpeng.jmod.interfaces.IExecutableObject;
 import com.jeffpeng.jmod.interfaces.IStagedObject;
-import com.jeffpeng.jmod.modintegration.decocraft.DecoCraftDyeFix;
+//import com.jeffpeng.jmod.modintegration.decocraft.DecoCraftDyeFix;
 import com.jeffpeng.jmod.modintegration.nei.NEI_JMODConfig;
 import com.jeffpeng.jmod.registry.BlockMaterialRegistry;
 import com.jeffpeng.jmod.util.ForgeDeepInterface;
@@ -24,6 +24,7 @@ import com.jeffpeng.jmod.util.actions.RemoveChestLoot;
 import com.jeffpeng.jmod.util.actions.RemoveRecipe;
 import com.jeffpeng.jmod.util.actions.RemoveSmeltingRecipe;
 import com.jeffpeng.jmod.util.actions.SetBlockProperties;
+import com.jeffpeng.jmod.util.actions.applecore.ModifyFoodValue;
 import com.jeffpeng.jmod.util.actions.chisel.AddCarvingVariation;
 import com.jeffpeng.jmod.util.actions.rotarycraft.AddGrinderRecipeDescriptor;
 
@@ -111,6 +112,7 @@ public class JMOD implements IFMLLoadingPlugin {
 
 		if(Loader.isModLoaded("RotaryCraft"))		execute(AddGrinderRecipeDescriptor.class);
 		if(Loader.isModLoaded("chisel"))			execute(AddCarvingVariation.class);
+		if(Loader.isModLoaded("applecore"))			execute(ModifyFoodValue.class);
 		Lib.patchTools();
 		Lib.patchArmor();
 		
@@ -127,7 +129,7 @@ public class JMOD implements IFMLLoadingPlugin {
 		execute(AddSmeltingRecipe.class);
 		execute(RemoveChestLoot.class);
 		execute(AddChestLoot.class);
-		if(Loader.isModLoaded("props"))			DecoCraftDyeFix.fix();
+		//if(Loader.isModLoaded("props"))			DecoCraftDyeFix.fix();
 		
 	}
 	

--- a/src/main/java/com/jeffpeng/jmod/JMOD.java
+++ b/src/main/java/com/jeffpeng/jmod/JMOD.java
@@ -12,7 +12,8 @@ import com.jeffpeng.jmod.asm.JMODObfuscationHelper;
 import com.jeffpeng.jmod.crafting.ToolUnbreaker;
 import com.jeffpeng.jmod.interfaces.IExecutableObject;
 import com.jeffpeng.jmod.interfaces.IStagedObject;
-//import com.jeffpeng.jmod.modintegration.decocraft.DecoCraftDyeFix;
+import com.jeffpeng.jmod.modintegration.applecore.AppleCoreModifyFoodValues;
+import com.jeffpeng.jmod.modintegration.decocraft.DecoCraftDyeFix;
 import com.jeffpeng.jmod.modintegration.nei.NEI_JMODConfig;
 import com.jeffpeng.jmod.registry.BlockMaterialRegistry;
 import com.jeffpeng.jmod.util.ForgeDeepInterface;
@@ -104,6 +105,10 @@ public class JMOD implements IFMLLoadingPlugin {
 		broadcast(event);
 		if(GLOBALCONFIG.preventToolBreaking) 	MinecraftForge.EVENT_BUS.register(new ToolUnbreaker());
 		if(Loader.isModLoaded("NotEnoughItem"))	new NEI_JMODConfig();
+		
+		if(Loader.isModLoaded("AppleCore"))	{
+			MinecraftForge.EVENT_BUS.register(AppleCoreModifyFoodValues.getInstance());
+		}
 	}
 
 	
@@ -112,7 +117,7 @@ public class JMOD implements IFMLLoadingPlugin {
 
 		if(Loader.isModLoaded("RotaryCraft"))		execute(AddGrinderRecipeDescriptor.class);
 		if(Loader.isModLoaded("chisel"))			execute(AddCarvingVariation.class);
-		if(Loader.isModLoaded("applecore"))			execute(ModifyFoodValue.class);
+		if(Loader.isModLoaded("AppleCore"))			execute(ModifyFoodValue.class);
 		Lib.patchTools();
 		Lib.patchArmor();
 		
@@ -129,7 +134,7 @@ public class JMOD implements IFMLLoadingPlugin {
 		execute(AddSmeltingRecipe.class);
 		execute(RemoveChestLoot.class);
 		execute(AddChestLoot.class);
-		//if(Loader.isModLoaded("props"))			DecoCraftDyeFix.fix();
+		if(Loader.isModLoaded("props"))			DecoCraftDyeFix.fix();
 		
 	}
 	

--- a/src/main/java/com/jeffpeng/jmod/modintegration/applecore/AppleCoreModifyFoodValues.java
+++ b/src/main/java/com/jeffpeng/jmod/modintegration/applecore/AppleCoreModifyFoodValues.java
@@ -1,0 +1,38 @@
+package com.jeffpeng.jmod.modintegration.applecore;
+
+import java.util.HashMap;
+
+import cpw.mods.fml.common.eventhandler.EventPriority;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import squeek.applecore.api.food.FoodEvent;
+import squeek.applecore.api.food.FoodValues;
+
+
+public class AppleCoreModifyFoodValues {
+
+    private static AppleCoreModifyFoodValues instance = new AppleCoreModifyFoodValues();
+
+    private AppleCoreModifyFoodValues(){}
+
+    public static AppleCoreModifyFoodValues getInstance(){
+    	return instance;
+    }
+	
+	private HashMap<String, FoodValues> foodItems = new HashMap<String, FoodValues>();
+
+	
+	public void addModifedFoodValue(String foodUnlocalizedName, int hunger, float saturationModifier) {
+		FoodValues val = new FoodValues(hunger, saturationModifier);
+		foodItems.put(foodUnlocalizedName, val);
+	}
+	
+	
+	@SubscribeEvent(priority = EventPriority.HIGHEST)
+    public void getModifiedFoodValues(FoodEvent.GetFoodValues event) {
+		FoodValues val = foodItems.get(event.food.getUnlocalizedName());
+		if(val != null) {
+			event.foodValues = val;
+		}
+    }
+	
+}

--- a/src/main/java/com/jeffpeng/jmod/modintegration/applecore/AppleCoreModifyFoodValues.java
+++ b/src/main/java/com/jeffpeng/jmod/modintegration/applecore/AppleCoreModifyFoodValues.java
@@ -2,11 +2,15 @@ package com.jeffpeng.jmod.modintegration.applecore;
 
 import java.util.HashMap;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.event.FMLInterModComms;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import net.minecraft.item.ItemStack;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
 import squeek.applecore.api.food.FoodEvent;
 import squeek.applecore.api.food.FoodValues;
 
@@ -15,32 +19,47 @@ public class AppleCoreModifyFoodValues {
 
     private static AppleCoreModifyFoodValues instance = new AppleCoreModifyFoodValues();
 
-    private AppleCoreModifyFoodValues(){}
+    
+	private Logger log;
+    
+    private AppleCoreModifyFoodValues(){
+		this.log = LogManager.getLogger("AppleCore Mod Intergration");
+    }
 
     public static AppleCoreModifyFoodValues getInstance(){
     	return instance;
     }
 	
 	private HashMap<String, FoodValues> foodItems = new HashMap<String, FoodValues>();
+	private static String BLACKLIST_FOOD = "BlacklistFood";
+	public static String HUNGEROVERHAUL_MODID = "HungerOverhaul";
 
-	
-	public void addModifedFoodValue(ItemStack foodStack, int hunger, float saturationModifier) {
+	public void addModifedFoodValue(UniqueIdentifier uid, int hunger, float saturationModifier) {
 		FoodValues val = new FoodValues(hunger, saturationModifier);
-		foodItems.put(foodStack.getUnlocalizedName(), val);
+		
+		String itemStr = uid.modId + ":" + uid.name;
+		
+		foodItems.put(itemStr, val);
+		log.info("addModifedFoodValue - FoodName: {} hunger: {} saturation: {}", 
+							uid, hunger, saturationModifier);
 		
 		//Send a message, So that HungerOverhaul does not change my values back..
-		if(Loader.isModLoaded("HungerOverhaul")) {
-			FMLInterModComms.sendMessage("HungerOverhaul", "BlacklistFood", foodStack);
+		if(Loader.isModLoaded(HUNGEROVERHAUL_MODID)) {
+			FMLInterModComms.sendMessage(HUNGEROVERHAUL_MODID, BLACKLIST_FOOD, itemStr);
 		}
 
 	}
 	
-	
-	@SubscribeEvent(priority = EventPriority.HIGHEST)
+	@SubscribeEvent(priority = EventPriority.NORMAL)
     public void getModifiedFoodValues(FoodEvent.GetFoodValues event) {
-		FoodValues val = foodItems.get(event.food.getUnlocalizedName());
+		
+		UniqueIdentifier uid = GameRegistry.findUniqueIdentifierFor(event.food.getItem());
+		String itemStr = uid.modId + ":" + uid.name;
+		
+		FoodValues val = foodItems.get(itemStr);
 		if(val != null) {
-			event.foodValues = val;
+			
+			event.foodValues = new FoodValues(val.hunger, val.saturationModifier);
 		}
     }
 	

--- a/src/main/java/com/jeffpeng/jmod/modintegration/applecore/AppleCoreModifyFoodValues.java
+++ b/src/main/java/com/jeffpeng/jmod/modintegration/applecore/AppleCoreModifyFoodValues.java
@@ -2,8 +2,11 @@ package com.jeffpeng.jmod.modintegration.applecore;
 
 import java.util.HashMap;
 
+import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.event.FMLInterModComms;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import net.minecraft.item.ItemStack;
 import squeek.applecore.api.food.FoodEvent;
 import squeek.applecore.api.food.FoodValues;
 
@@ -21,9 +24,15 @@ public class AppleCoreModifyFoodValues {
 	private HashMap<String, FoodValues> foodItems = new HashMap<String, FoodValues>();
 
 	
-	public void addModifedFoodValue(String foodUnlocalizedName, int hunger, float saturationModifier) {
+	public void addModifedFoodValue(ItemStack foodStack, int hunger, float saturationModifier) {
 		FoodValues val = new FoodValues(hunger, saturationModifier);
-		foodItems.put(foodUnlocalizedName, val);
+		foodItems.put(foodStack.getUnlocalizedName(), val);
+		
+		//Send a message, So that HungerOverhaul does not change my values back..
+		if(Loader.isModLoaded("HungerOverhaul")) {
+			FMLInterModComms.sendMessage("HungerOverhaul", "BlacklistFood", foodStack);
+		}
+
 	}
 	
 	

--- a/src/main/java/com/jeffpeng/jmod/scripting/ScriptObject.java
+++ b/src/main/java/com/jeffpeng/jmod/scripting/ScriptObject.java
@@ -23,6 +23,7 @@ public class ScriptObject extends OwnedObject {
 	public Global Global = new Global(owner);
 	public RotaryCraft RotaryCraft = new RotaryCraft(owner);
 	public Chisel Chisel = new Chisel(owner);
+	public Applecore Applecore = new Applecore(owner);
 	public Sync Sync = new Sync(owner);
 	
 	public void load(String script){

--- a/src/main/java/com/jeffpeng/jmod/scripting/mods/Applecore.java
+++ b/src/main/java/com/jeffpeng/jmod/scripting/mods/Applecore.java
@@ -1,0 +1,16 @@
+package com.jeffpeng.jmod.scripting.mods;
+
+import com.jeffpeng.jmod.JMODRepresentation;
+import com.jeffpeng.jmod.primitives.OwnedObject;
+import com.jeffpeng.jmod.util.actions.applecore.ModifyFoodValue;
+
+public class Applecore extends OwnedObject {
+
+	public Applecore(JMODRepresentation owner){
+		super(owner);
+	}
+	
+	public void modifyFoodValue(String food, int hunger, float saturationModifier) {
+		if(owner.testForMod("AppleCore")) new ModifyFoodValue(owner, food, hunger, saturationModifier);
+	}
+}

--- a/src/main/java/com/jeffpeng/jmod/util/actions/applecore/ModifyFoodValue.java
+++ b/src/main/java/com/jeffpeng/jmod/util/actions/applecore/ModifyFoodValue.java
@@ -5,11 +5,13 @@ import com.jeffpeng.jmod.modintegration.applecore.AppleCoreModifyFoodValues;
 import com.jeffpeng.jmod.primitives.BasicAction;
 
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.common.registry.GameRegistry.UniqueIdentifier;
 import net.minecraft.item.ItemStack;
 
 public class ModifyFoodValue extends BasicAction {
 
-	ItemStack foodStack;
+	UniqueIdentifier uid;
 	String foodName;
 	int hunger;
 	float saturationModifier;
@@ -24,11 +26,15 @@ public class ModifyFoodValue extends BasicAction {
 	@Override
 	public boolean on(FMLPostInitializationEvent event){
 		
-		ItemStack fs = (ItemStack) lib.stringToItemStack(foodName);
-		if(fs != null && fs instanceof ItemStack) {
-			foodStack = fs;
+		ItemStack stack = (ItemStack) lib.stringToItemStack(foodName);
+		
+		if(stack != null && stack instanceof ItemStack) {
+			uid = GameRegistry.findUniqueIdentifierFor(stack.getItem());
 			
-			valid = true;
+			if(uid != null) {
+				valid = true;
+			}
+			
 		}
 		else {
 			valid = false;
@@ -41,6 +47,6 @@ public class ModifyFoodValue extends BasicAction {
 	public void execute() {
 		AppleCoreModifyFoodValues store = AppleCoreModifyFoodValues.getInstance();
 		
-		store.addModifedFoodValue(foodStack, hunger, saturationModifier);
+		store.addModifedFoodValue(uid, hunger, saturationModifier);
 	}
 }

--- a/src/main/java/com/jeffpeng/jmod/util/actions/applecore/ModifyFoodValue.java
+++ b/src/main/java/com/jeffpeng/jmod/util/actions/applecore/ModifyFoodValue.java
@@ -9,7 +9,7 @@ import net.minecraft.item.ItemStack;
 
 public class ModifyFoodValue extends BasicAction {
 
-	String foodUnlocalizedName;
+	ItemStack foodStack;
 	String foodName;
 	int hunger;
 	float saturationModifier;
@@ -26,7 +26,7 @@ public class ModifyFoodValue extends BasicAction {
 		
 		ItemStack fs = (ItemStack) lib.stringToItemStack(foodName);
 		if(fs != null && fs instanceof ItemStack) {
-			foodUnlocalizedName = fs.getUnlocalizedName();
+			foodStack = fs;
 			
 			valid = true;
 		}
@@ -41,6 +41,6 @@ public class ModifyFoodValue extends BasicAction {
 	public void execute() {
 		AppleCoreModifyFoodValues store = AppleCoreModifyFoodValues.getInstance();
 		
-		store.addModifedFoodValue(foodUnlocalizedName, hunger, saturationModifier);
+		store.addModifedFoodValue(foodStack, hunger, saturationModifier);
 	}
 }

--- a/src/main/java/com/jeffpeng/jmod/util/actions/applecore/ModifyFoodValue.java
+++ b/src/main/java/com/jeffpeng/jmod/util/actions/applecore/ModifyFoodValue.java
@@ -1,0 +1,46 @@
+package com.jeffpeng.jmod.util.actions.applecore;
+
+import com.jeffpeng.jmod.JMODRepresentation;
+import com.jeffpeng.jmod.modintegration.applecore.AppleCoreModifyFoodValues;
+import com.jeffpeng.jmod.primitives.BasicAction;
+
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import net.minecraft.item.ItemStack;
+
+public class ModifyFoodValue extends BasicAction {
+
+	String foodUnlocalizedName;
+	String foodName;
+	int hunger;
+	float saturationModifier;
+	
+	public ModifyFoodValue(JMODRepresentation owner, String food, int hunger, float saturationModifier) {
+		super(owner);
+		this.foodName = food;
+		this.hunger = hunger;
+		this.saturationModifier = saturationModifier;
+	}
+
+	@Override
+	public boolean on(FMLPostInitializationEvent event){
+		
+		ItemStack fs = (ItemStack) lib.stringToItemStack(foodName);
+		if(fs != null && fs instanceof ItemStack) {
+			foodUnlocalizedName = fs.getUnlocalizedName();
+			
+			valid = true;
+		}
+		else {
+			valid = false;
+		}
+		
+		return valid;
+	}
+	
+	@Override
+	public void execute() {
+		AppleCoreModifyFoodValues store = AppleCoreModifyFoodValues.getInstance();
+		
+		store.addModifedFoodValue(foodUnlocalizedName, hunger, saturationModifier);
+	}
+}


### PR DESCRIPTION
This Pull Request adds a new function to script modifications to food values.

For example:
`Applcore.modifyFoodValue("minecraft:carrot", 10, 0.5);`

Would set carrots to restore 10 hunger and 5 Saturation. 

Also if HungerOverhaul is loaded sends it a [IMC](https://github.com/progwml6/HungerOverhaul/wiki) so it doesn't over write any modifications to food values.
