### PR TITLE
Feature/3.tool material fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,12 +45,18 @@ repositories {
 	maven {
 		url "http://www.ryanliptak.com/maven/"
 	}
+	
+	maven {
+        url 'http://maven.tterrag.com/'
+    }
 }
 
 dependencies {
 	compile 'org.ow2.asm:asm-debug-all:5.0.3'
 	
 	compile "applecore:AppleCore:1.7.10-1.3.1+171.f62ad:api"
+	
+	compile "exnihilo:Ex-Nihilo:1.38-49:deobf"
 	
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..

--- a/build.gradle
+++ b/build.gradle
@@ -32,13 +32,13 @@ minecraft {
 }
 
 jar {
-		manifest {
-			attributes 'FMLAT': 'jmod_at.cfg'
-			attributes 'FMLCorePlugin': 'com.jeffpeng.jmod.JMOD','FMLCorePluginContainsFMLMod': 'false'
-			attributes 'Main-Class': 'com.jeffpeng.jmod.validator.Validator'
-		}
-		
-		classifier = 'complete'
+	manifest {
+		attributes 'FMLAT': 'jmod_at.cfg'
+		attributes 'FMLCorePlugin': 'com.jeffpeng.jmod.JMOD','FMLCorePluginContainsFMLMod': 'false'
+		attributes 'Main-Class': 'com.jeffpeng.jmod.validator.Validator'
+	}
+	
+	classifier = 'complete'
 }
 
 repositories {
@@ -49,6 +49,11 @@ repositories {
 	maven {
         url 'http://maven.tterrag.com/'
     }
+    
+    maven {
+        name = "chickenbones"
+        url = "http://chickenbones.net/maven/"
+    }
 }
 
 dependencies {
@@ -58,6 +63,8 @@ dependencies {
 	
 	compile "exnihilo:Ex-Nihilo:1.38-49:deobf"
 	
+	compile "codechicken:CodeChickenLib:1.7.10-1.1.1.104:dev"
+		
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..
     //compile "some.group:artifact:version:classifier"
@@ -78,22 +85,19 @@ sourceSets {
     main {
         java {
             srcDirs += 'src/api/java'
-            srcDirs += 'src/main/java/'
         }
         
         resources {
             srcDir "src/main/resources/"
-            
-            
         }
     }
     
-    pluginIgniter {
+/*    pluginIgniter {
     	java {
     		srcDirs += 'src/main/java/jmodplugins/igniter'
     	}
     }
-    
+  */  
     
 }
 

--- a/src/main/java/com/jeffpeng/jmod/JMOD.java
+++ b/src/main/java/com/jeffpeng/jmod/JMOD.java
@@ -124,8 +124,10 @@ public class JMOD implements IFMLLoadingPlugin {
 
 	
 	public void on(FMLPostInitializationEvent event) {
-		Lib.patchTools();
-		Lib.patchArmor();
+		Patcher.getInstance().patchTools();
+		Patcher.getInstance().patchArmor();
+		// Lib.patchTools();
+		// Lib.patchArmor();
 	}
 	
 	

--- a/src/main/java/com/jeffpeng/jmod/Lib.java
+++ b/src/main/java/com/jeffpeng/jmod/Lib.java
@@ -508,12 +508,12 @@ public class Lib extends OwnedObject {
 		@SuppressWarnings("unchecked")
 		Set<String> allItems = GameData.getItemRegistry().getKeys();
 
+		
+		
 		for (String itemname : allItems) {
 
 			Item item = gamereg.getObject(itemname);
 			if (item instanceof ItemTool || item instanceof ItemHoe || item instanceof ItemSword) {
-
-				
 
 				if (item.getClass().getCanonicalName().contains("Reika.RotaryCraft")) {
 					continue;

--- a/src/main/java/com/jeffpeng/jmod/Patcher.java
+++ b/src/main/java/com/jeffpeng/jmod/Patcher.java
@@ -1,0 +1,198 @@
+package com.jeffpeng.jmod;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import com.jeffpeng.jmod.actions.AddToolMaterial;
+import com.jeffpeng.jmod.util.Reflector;
+
+import cpw.mods.fml.common.registry.FMLControlledNamespacedRegistry;
+import cpw.mods.fml.common.registry.GameData;
+import fi.dy.masa.enderutilities.item.tool.ItemEnderTool;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemArmor;
+import net.minecraft.item.ItemAxe;
+import net.minecraft.item.Item.ToolMaterial;
+import net.minecraft.item.ItemArmor.ArmorMaterial;
+import net.minecraft.item.ItemHoe;
+import net.minecraft.item.ItemPickaxe;
+import net.minecraft.item.ItemSpade;
+import net.minecraft.item.ItemSword;
+import net.minecraft.item.ItemTool;
+
+public class Patcher {
+	
+	private static Patcher instance = new Patcher();
+
+	private Patcher(){}
+
+	public static Patcher getInstance(){
+	    return instance;
+	}
+	
+	
+	/**
+	 * Patches tools to use any added ToolMaterials
+	 */
+	public void patchTools() {
+		FMLControlledNamespacedRegistry<Item> gamereg = GameData.getItemRegistry();
+
+		@SuppressWarnings("unchecked")
+		Set<String> allItems = GameData.getItemRegistry().getKeys();
+
+		allItems.stream()
+				.map(itemName -> gamereg.getObject(itemName))
+				.filter(isItemInstanceOf)
+				.forEach(item -> {
+					Optional<ToolMaterial> toolMat = lookUpToolMaterial.apply(item);
+					toolMat.ifPresent(mat -> {
+						updateToolMaterial.accept(item, mat);
+					});
+				});
+		
+	}
+	
+	/**
+	 * Filter for Items we can not patch
+	 */
+	private Predicate<Item> isItemInstanceOf = item -> 
+			  !item.getClass().getCanonicalName().contains("Reika.RotaryCraft") ||
+													   item instanceof ItemTool || 
+													   item instanceof ItemHoe  || 
+													   item instanceof ItemSword;
+
+    /**
+     * Finds the ToolMaterial to Patch our Tool with
+     * 
+     * Actions:
+     *  1. Gets tool's Material Name
+     *  2. first looks for it in list of added Tool Materials
+     *  3. If not found in added Tool Materials look in Minecraft's ToolMaterial enum
+     *  4. If tool material is still not found return empty, this will be skipped
+     */
+	private Function<Item, Optional<ToolMaterial>> lookUpToolMaterial = item -> {
+		Optional<String> toolmatname = Optional.empty();
+		
+		if (item instanceof ItemTool)
+			toolmatname = Optional.ofNullable( ((ItemTool) item).getToolMaterialName());
+		else if (item instanceof ItemHoe)
+			toolmatname = Optional.ofNullable( ((ItemHoe) item).getToolMaterialName());
+		else if (item instanceof ItemSword)
+			toolmatname = Optional.ofNullable( ((ItemSword) item).getToolMaterialName());
+
+		Optional<ToolMaterial> toolmat = toolmatname.flatMap(name -> 
+											Optional.ofNullable(AddToolMaterial.get(name)).map(add -> add.toolmat)
+													);
+		
+		if (!toolmat.isPresent()) {
+			try {
+				toolmat = toolmatname.flatMap(name -> Optional.ofNullable(ToolMaterial.valueOf(name)));
+			} catch (IllegalArgumentException e) {
+				toolmat = Optional.empty();
+			}
+		}
+		return toolmat;
+	};
+	
+	/**
+	 * Updates the Item to use a Tool Material.
+	 */
+	private BiConsumer<Item, ToolMaterial> updateToolMaterial = (item, toolmat) -> {
+		// Update the tool material
+		if (item instanceof ItemTool) {
+			if(item.getClass().getCanonicalName().contains("fi.dy.masa.enderutilities")){
+				Reflector endertoolreflector = new Reflector(item, ItemEnderTool.class);
+				endertoolreflector.set("material", toolmat).set("field_77865_bY",toolmat.getDamageVsEntity()+2F).set("field_77864_a", toolmat.getEfficiencyOnProperMaterial());
+				
+			} else {
+				item.setMaxDamage(toolmat.getMaxUses());
+				
+				Reflector itemreflector = new Reflector(item, ItemTool.class);
+				Float damagemodifier = 0F;
+				if (item instanceof ItemAxe)
+					damagemodifier = 3F;
+				if (item instanceof ItemPickaxe) {
+					damagemodifier = 2F;
+					item.setHarvestLevel("pickaxe", toolmat.getHarvestLevel());
+				}
+				if (item instanceof ItemSpade) {
+					damagemodifier = 1F;
+					item.setHarvestLevel("shovel", toolmat.getHarvestLevel());
+				}
+				
+				itemreflector.set(3, toolmat).set(2, toolmat.getDamageVsEntity() + damagemodifier)
+						.set(1, toolmat.getEfficiencyOnProperMaterial());
+				
+			}
+
+		}
+		if (item instanceof ItemHoe) {
+			new Reflector(item, ItemHoe.class).set(0, toolmat);
+		}
+		if (item instanceof ItemSword) {
+			new Reflector(item, ItemSword.class).set(1, toolmat).set(0, toolmat.getDamageVsEntity() + 4F);
+		}
+		
+		// if (item instanceof ItemShears) {
+		// }
+
+		// Update the max damage
+		if (item.getMaxDamage() > 0)
+			item.setMaxDamage(toolmat.getMaxUses());
+		
+		String itemname = item.getUnlocalizedName();
+		
+		if (item instanceof ItemTool)
+			JMOD.LOG.info("[tool patcher] " + itemname + " is a " + ((ItemTool) item).getToolMaterialName() + " tool (" + item.getClass().getName() + ")");
+		if (item instanceof ItemHoe)
+			JMOD.LOG.info("[tool patcher] " + itemname + " is a " + ((ItemHoe) item).getToolMaterialName() + " hoe (" + item.getClass().getName() + ")");
+		if (item instanceof ItemSword)
+			JMOD.LOG.info("[tool patcher] " + itemname + " is a " + ((ToolMaterial) new Reflector(item, ItemSword.class).get(1)).name() + " weapon (basically a sword) (" + item.getClass().getName() + ")");
+	};
+	
+	
+	/**
+	 * Patches Armor to use any added ArmorMaterial
+	 */
+	public void patchArmor() {
+
+		FMLControlledNamespacedRegistry<Item> gamereg = GameData.getItemRegistry();
+
+		@SuppressWarnings("unchecked")
+		Set<String> allItems = GameData.getItemRegistry().getKeys();
+
+		for (String itemname : allItems) {
+
+			Item item = gamereg.getObject(itemname);
+			if (item instanceof ItemArmor) {
+				
+				ItemArmor itemarmor = (ItemArmor) item;
+				
+				if (itemarmor.getClass().getCanonicalName().contains("Reika.RotaryCraft")) {
+					continue;
+				}
+
+				ArmorMaterial armormat = null;
+				String armormatname = itemarmor.getArmorMaterial().name();
+				
+
+				if (armormatname == null) continue;
+				else armormat = ArmorMaterial.valueOf(armormatname);
+
+				
+				// Update the tool material
+				
+				Reflector itemreflector = new Reflector(itemarmor, ItemArmor.class);
+				itemreflector.set(5,armormat.getDamageReductionAmount(itemarmor.armorType));
+				itemarmor.setMaxDamage(armormat.getDurability(itemarmor.armorType));
+
+				JMOD.LOG.info("[armor patcher] " + itemname + " is an armor (" + itemarmor.getClass().getName() + ")");
+				
+			}
+		}
+	}
+}


### PR DESCRIPTION
This should fix Issue #2 

This patch prioritizes new Tool Material added via AddToolMaterial over the Tool Materials found in the  minecraft ToolMaterial enum. I also found that I had to explicitly set `item.setHarvestLevel` for some tools.

I moved the Patching code to it's own class. It's big enough that I don't want to clutter `Lib.java`.

Todo:
 1. I haven't removed the old patching code from `Lib.java`. 
 2. I also haven't reviewed AddArmorMaterial, I would bet this kind of bug could happen there too.

